### PR TITLE
fix scalar tensor sbp in training sd

### DIFF
--- a/src/transformers/models/clip/modeling_oneflow_clip.py
+++ b/src/transformers/models/clip/modeling_oneflow_clip.py
@@ -671,7 +671,7 @@ class CLIPTextTransformer(nn.Module):
         # lazily create causal attention mask, with full attention between the vision tokens
         # pytorch uses additive attention mask; fill with -inf
         mask = torch.empty(bsz, seq_len, seq_len, dtype=dtype)
-        mask.fill_(torch.tensor(torch.finfo(dtype).min))
+        mask.fill_(torch.finfo(dtype).min)
         mask.triu_(1)  # zero out the lower diagonal
         mask = mask.unsqueeze(1)  # expand mask
         return mask


### PR DESCRIPTION
这个pr要做的:

解决训练sd时出现的bug:
```
 File "/home/chengpeng/transformers/src/transformers/models/clip/modeling_oneflow_clip.py", line 674, in _build_causal_attention_mask
    mask.fill_(torch.tensor(torch.finfo(dtype).min))
RuntimeError: Error: Split axis out of range (expected to be in range of [0, 0), but got 0!)
```
这里出现bug的原因是, 在用了global_mode的情况下, torch.tensor()创建的默认为S[0]的global tensor, 在只有一个数字的情况下面 会变成一个 scalar global tensor, 导致报错. 
